### PR TITLE
Home Conference Quick Link and ABZ'23 Information

### DIFF
--- a/.github/src/content/event/2023.md
+++ b/.github/src/content/event/2023.md
@@ -4,16 +4,15 @@ title: ABZ 2023 (Nancy, France)
 summary: 9th International Conference on Rigorous State-Based Methods
 event:   9th International Conference on Rigorous State-Based Methods
 
-# event_url: https://TODO
-# or integrate directly into the ABZ website!"
+event_url: https://abz2023.loria.fr
 
 location: "Nancy, France"
 
-date:     "2023-02-13"
-date_end: "2023-03-03"
+date:     "2023-05-30"
+date_end: "2023-06-02"
 all_day:  true
 
-publishDate: 2020-06-19T16:42:07+02:00
+# publishDate: 2020-06-19T16:42:07+02:00
 
 tags:
 - ABZ'23
@@ -27,5 +26,3 @@ projects:
 #   name: Follow
 #   url: https://twitter.com/georgecushen
 ---
-
-**Note:** The concrete conference date is not fixed yet and will be updated in the near future!

--- a/.github/src/content/home/about.md
+++ b/.github/src/content/home/about.md
@@ -10,7 +10,13 @@ twitter:
   id: ABZ_Conference
 # width:  400
   height: 500
+
+event:
+  link: 2023
+  text: ABZ'23
+  
 ---
+
 The ABZ conference series is dedicated to the cross-fertilization of state-based and machine-based formal [methods](/methods). The naming "ABZ" has historical reasons and is not meant to favor any methods. On the contrary, any state-based or even hybrid formal method is welcome in the ABZ community! 
 
 The following enumeration is just an excerpt of the methods from which research results have been published on ABZ. The methods [Abstract State Machines (ASM)](/method/asm), [Alloy](/method/alloy), [Classical B](/method/b), [Event-B](/method/event-b), [Temporal Logic of Actions (TLA)](/method/tla), [Vienna Development Method (VDM)](/method/vdm), [Z Notation](/method/z), and much more share a common conceptual foundation and are widely used in both academia and industry for the design and analysis of hardware and software systems.

--- a/.github/src/layouts/partials/widgets/home.html
+++ b/.github/src/layouts/partials/widgets/home.html
@@ -4,6 +4,9 @@
 {{ $twitter_id     := $twitter.id }}
 {{ $twitter_width  := $twitter.width  | default "400" }}
 {{ $twitter_height := $twitter.height | default "650" }}
+{{ $event      := .page.Params.event }}
+{{ $event_link := $event.link }}
+{{ $event_text := $event.text }}
 
 <div class="universal-wrapper">
   <img src="{{ $banner }}" />
@@ -13,6 +16,14 @@
       {{ .page.Content }}
     </div>
     <div class="col-md-4">
+      <div style="text-align: center; display: block; cursor: pointer;" class="card" onclick="location.href='/{{ $event_link }}';">
+	<div class="card-body">
+	  <h5 class="card-title">Upcoming Conference</h5>
+	  <h6 class="card-subtitle mb-2 text-muted"><a href="/{{ $event_link }}">{{ $event_text }}</a></h6>
+	  <!-- p class="card-text">text</p>
+	  <!-- a href="#" class="card-link">link</a -->
+        </div>
+      </div>
       <div style="text-align: center;">
 	<meta name="twitter:dnt" content="on">
 	<a class="twitter-timeline"


### PR DESCRIPTION
This PR introduces the following changes:

* introduces a new quick link to the upcoming conferences which is configurable through the home page (see `.github/src/content/home/about.md`)
* updated the ABZ'23 link and date information
