### PR TITLE
Configuration: update banner location URI to point to RSBM kind

### DIFF
--- a/.github/src/content/home/about.md
+++ b/.github/src/content/home/about.md
@@ -4,7 +4,7 @@ headless: false
 active: true
 weight: 10
 
-banner: https://github.com/abz-conf/abz-conf.logo/raw/master/src/banner.svg
+banner: https://github.com/abz-conf/abz-conf.logo/raw/master/src/banner_rsbm.svg
 
 twitter:
   id: ABZ_Conference

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ build: .github/src/themes/academic
 	(cd .github/src; hugo)
 
 serve: build
-	(cd .github/src; hugo --i18n-warnings server)
+	(cd .github/src; hugo server)
 
 serve-with-drafts: build
-	(cd .github/src; hugo --i18n-warnings server -D)
+	(cd .github/src; hugo server -D)
 
 clean:
 	rm -rf .github/obj


### PR DESCRIPTION
This PR introduces the following changes:
* updates the banner to the new plain "Rigorous State Based Method" syle
* closes #35 

This is the new website homepage with the banner:
![image](https://user-images.githubusercontent.com/6830431/184365955-af435325-576f-4402-abe9-3ae597655758.png)
