### PR TITLE
Feature/17 submenu

### DIFF
--- a/.github/src/config/_default/menus.toml
+++ b/.github/src/config/_default/menus.toml
@@ -48,3 +48,15 @@
 #   name = "Site Notice"
 #   url = "site/notice"
 #   weight = 100
+
+[[context]]
+  name = "References"
+  url = "method/asm"
+  identifier = "bibtex-references"
+  weight = 1
+
+# [[context]]
+#   name = "Sub-Menu Entry"
+#   url = "path/of/page"
+#   identifier = "relative/or/absolute/path/to/other/page"
+#   weight = 2

--- a/.github/src/content/project/abz23.md
+++ b/.github/src/content/project/abz23.md
@@ -1,5 +1,5 @@
 ---
-title: "AMAN Case Study (ABZ 2020)"
+title: "AMAN Case Study (ABZ 2023)"
 
 date: 2023
 
@@ -10,5 +10,8 @@ categories: []
 
 featured: false
 ---
-This document presents the case study for ABZ 2023 conference. The case study introduces a safety critical interactive system called
-AMAN (Arrival MANager) which is a partly-autonomous scheduler of landing sequences of aircraft in airports. This interactive systems interleaves Air Traffic Controllers activities with automation in AMAN. While some AMAN systems are currently deployed in airports, we consider here only a subset of functions which represent a challenge in modelling and verification.
+
+This document presents the case study for ABZ 2023 conference.
+The case study introduces a safety critical interactive system called AMAN (Arrival MANager) which is a partly-autonomous scheduler of landing sequences of aircraft in airports.
+This interactive systems interleaves Air Traffic Controllers activities with automation in AMAN.
+While some AMAN systems are currently deployed in airports, we consider here only a subset of functions which represent a challenge in modelling and verification.

--- a/.github/src/layouts/partials/navbar.html
+++ b/.github/src/layouts/partials/navbar.html
@@ -155,3 +155,36 @@
 
   </div><!-- /.container -->
 </nav>
+
+{{- if .Site.Menus.context }}
+{{ $page := trim $.Page.RelPermalink "/"}}
+<style>
+div.nav1 ul li
+{
+    text-align: center;
+    display:inline;
+    padding: 10px;
+    margin: 10px;
+    list-style-type: none;
+    line-height: 2em;
+    background-color: #F0F0F0;
+}
+</style>
+<div class="universal-wrapper nav1">
+  <div style="text-align: left;">
+  <ul class="">
+    {{- range .Site.Menus.context }}
+    {{- if .Name }}
+    {{ if eq .URL $page }}
+    <a style="" href="{{ .Identifier }}">
+      <li class="">
+        <span class="">{{ .Name }}</span>
+      </li>
+    </a>
+    {{- end }}
+    {{- end }}
+    {{- end }}
+  </ul>
+  </div>
+</div>
+{{- end }}


### PR DESCRIPTION
This PR introduces the following changes:

* introduces generic `context`-aware sub-menu rendering e.g. for the ASM method with explicit `References` entry to the BibTex entries as an example for now (see **Figure 1**)
* can be used an every page level and can be configured in the `menus.toml` file (see 31a0138f8fdab1f722bcfaaa79cbcbc80ef4d461)
* closes: #17 

---

**Figure 1**: Example sub-menu rendering for the ASM method

![Peek 2023-05-07 14-21](https://user-images.githubusercontent.com/6830431/236677449-3b705bcc-5248-4d27-a83d-ffccf37afc4e.gif)
 